### PR TITLE
Manually bump to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	k8s.io/apimachinery v0.26.5
 	k8s.io/client-go v0.26.5
 	k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2
-	knative.dev/eventing v0.38.1-0.20230901050135-11d9e8ad8b24
+	knative.dev/eventing v0.38.1-0.20230904140737-25400fbd47b1
 	knative.dev/hack v0.0.0-20230818155117-9cc05a31e8c0
 	knative.dev/pkg v0.0.0-20230901225035-211243a92d2f
 	knative.dev/reconciler-test v0.0.0-20230901013135-51e7751247b7

--- a/go.sum
+++ b/go.sum
@@ -957,8 +957,8 @@ k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 h1:+70TFaan3hfJzs+7VK2o+O
 k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280/go.mod h1:+Axhij7bCpeqhklhUTe3xmOn6bWxolyZEeyaFpjGtl4=
 k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2 h1:GfD9OzL11kvZN5iArC6oTS7RTj7oJOIfnislxYlqTj8=
 k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-knative.dev/eventing v0.38.1-0.20230901050135-11d9e8ad8b24 h1:TKT5gHlVt0ahmuUPOUp3Wru9FKPJgop3PRhuWsuRniM=
-knative.dev/eventing v0.38.1-0.20230901050135-11d9e8ad8b24/go.mod h1:dWcR2GxWiNhMCV65YxbTBvj5V+E8R5nN6sd8qbyLnbY=
+knative.dev/eventing v0.38.1-0.20230904140737-25400fbd47b1 h1:5seA68batA0adI7IyXrZE14DVGaNxCod6l8SZrXMkls=
+knative.dev/eventing v0.38.1-0.20230904140737-25400fbd47b1/go.mod h1:+xPiZu45U9pBUE0r/YipUFNJKd6keJgssYA7XvoVZko=
 knative.dev/hack v0.0.0-20230818155117-9cc05a31e8c0 h1:n9YEGYuoj31pAkhGlNL+xTQAeXKYTLeMmIZLWA9fAeo=
 knative.dev/hack v0.0.0-20230818155117-9cc05a31e8c0/go.mod h1:yk2OjGDsbEnQjfxdm0/HJKS2WqTLEFg/N6nUs6Rqx3Q=
 knative.dev/pkg v0.0.0-20230901225035-211243a92d2f h1:I60WBu0TRBhQ1ke8s3xfhn3fXo2OOLv+ebCoTwUdddU=

--- a/vendor/knative.dev/eventing/pkg/scheduler/statefulset/scheduler.go
+++ b/vendor/knative.dev/eventing/pkg/scheduler/statefulset/scheduler.go
@@ -110,36 +110,6 @@ func New(ctx context.Context, cfg *Config) (scheduler.Scheduler, error) {
 	return s, nil
 }
 
-// NewScheduler creates a new scheduler with pod autoscaling enabled.
-// Deprecated: Use New
-func NewScheduler(ctx context.Context,
-	namespace, name string,
-	lister scheduler.VPodLister,
-	refreshPeriod time.Duration,
-	capacity int32,
-	schedulerPolicy scheduler.SchedulerPolicyType,
-	nodeLister corev1listers.NodeLister,
-	evictor scheduler.Evictor,
-	schedPolicy *scheduler.SchedulerPolicy,
-	deschedPolicy *scheduler.SchedulerPolicy) scheduler.Scheduler {
-
-	cfg := &Config{
-		StatefulSetNamespace: namespace,
-		StatefulSetName:      name,
-		PodCapacity:          capacity,
-		RefreshPeriod:        refreshPeriod,
-		SchedulerPolicy:      schedulerPolicy,
-		SchedPolicy:          schedPolicy,
-		DeschedPolicy:        deschedPolicy,
-		Evictor:              evictor,
-		VPodLister:           lister,
-		NodeLister:           nodeLister,
-	}
-
-	s, _ := New(ctx, cfg)
-	return s
-}
-
 type Pending map[types.NamespacedName]int32
 
 func (p Pending) Total() int32 {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1264,7 +1264,7 @@ k8s.io/utils/net
 k8s.io/utils/pointer
 k8s.io/utils/strings/slices
 k8s.io/utils/trace
-# knative.dev/eventing v0.38.1-0.20230901050135-11d9e8ad8b24
+# knative.dev/eventing v0.38.1-0.20230904140737-25400fbd47b1
 ## explicit; go 1.19
 knative.dev/eventing/cmd/heartbeats
 knative.dev/eventing/pkg/adapter/v2


### PR DESCRIPTION
## Proposed Changes

- bump to latest
- remove depracted function usage of statefulset scheduler (as per https://github.com/knative/eventing/pull/6736)

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
